### PR TITLE
Remove horizontal scroll bar from the bottom

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -28,7 +28,7 @@ body {
   font-family: 'Montserrat', sans-serif;
   font-weight: 400;
 
-  width: 100%;
+  max-width: 100%;
 }
 
 h2 {
@@ -70,12 +70,12 @@ a {
 
 .calculate_score_button {
   margin: auto;
-  text-decoration:none;
-  background-color:var(--white);
-  color:var(--black);
+  text-decoration: none;
+  background-color: var(--white);
+  color: var(--black);
   padding: 1em;
   font-size: 1em;
-  font-weight:00;
+  font-weight: 00;
   border-radius: 0.5em;
   transition: background-color 0.5s ease;
 }
@@ -149,6 +149,8 @@ a {
   justify-content: center;
   align-content: center;
   margin-top: 1em;
+
+  width: 90%;
 }
 
 .side-effects-intro {
@@ -363,6 +365,7 @@ footer p a {
 .cloud-row {
   display: flex;
   justify-content: space-between;
+  max-width: 100%;
 }
 
 .lg-cloud,

--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -28,7 +28,7 @@ body {
   font-family: 'Montserrat', sans-serif;
   font-weight: 400;
 
-  max-width: 100%;
+  width: 100%;
 }
 
 h2 {


### PR DESCRIPTION
I looked into this and it wasn't the clouds causing the scroll bar, it was the side-effects section. I set a max-width on the clouds just in case, and set width on side effects.

I checked out the Galaxy Fold display in case this was causing the problem we'd discovered earlier, and while there's no scroll bar anymore, there is still a tiny gap on the right side of the screen and window.innerWidth still returns 289px instead of 280px. I think this is just an issue with the Galaxy Fold setting at this point, and it's probably not worth us worrying about too much.